### PR TITLE
Order by created ascending to get the oldest, then by descending for …

### DIFF
--- a/Heroesprofile.Uploader.Common/Manager.cs
+++ b/Heroesprofile.Uploader.Common/Manager.cs
@@ -181,7 +181,7 @@ namespace Heroesprofile.Uploader.Common
             var lookup = new HashSet<ReplayFile>(replays);
             var comparer = new ReplayFile.ReplayFileComparer();
             replays.AddRange(_monitor.ScanReplays().Select(x => new ReplayFile(x)).Where(x => !lookup.Contains(x, comparer)));
-            return replays.OrderByDescending(x => x.Created).ToList();
+            return replays.OrderBy(x => x.Created).ThenByDescending(x=> x.Created.TimeOfDay).ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
I changed the replay order to be listed ascending so that the oldest created is first. Then added order by descending on the time of day. Fixes #3